### PR TITLE
Service iterations

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ app.get('/api/v0.1/recap/nypl-bibs', (req, res, next) => {
 
   return resolveBibId
     // Get bib & item records:
-    .then((bibId) => dataApi.getBibAndItemsByBibId(bibId))
+    .then((bibId) => dataApi.getBibAndItemsByBibId(bibId, barcode))
     // Format as scsb xml:
     .then((bibAndItems) => {
       let [bib, items] = bibAndItems

--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ app.get('/api/v0.1/recap/nypl-bibs', (req, res, next) => {
 
   let barcode = req.query.barcode
   let bnumber = req.query.bnumber
+  let includeFullBibTree = (req.query.includeFullBibTree === 'true')
 
   if (!customerCode || !(barcode || bnumber)) {
     return handleError(new errors.InvalidParameterError('Missing barcode and customercode paramaters or bnumber and customercode paramater'), req, res)
@@ -51,7 +52,7 @@ app.get('/api/v0.1/recap/nypl-bibs', (req, res, next) => {
 
   return resolveBibId
     // Get bib & item records:
-    .then((bibId) => dataApi.getBibAndItemsByBibId(bibId, barcode))
+    .then((bibId) => dataApi.getBibAndItemsByBibId(bibId, barcode, includeFullBibTree))
     // Format as scsb xml:
     .then((bibAndItems) => {
       let [bib, items] = bibAndItems

--- a/lib/data-api.js
+++ b/lib/data-api.js
@@ -57,17 +57,25 @@ class DataApi {
    *
    *  @param {string} bibId The bibId to look up.
    *  @param {string} barcode The barcode of the item to attach.
+   *  @param {boolean} includeFullBibTree Include the full bib tree.
    *
    *  @returns {array} with exactly two elements:
    *   1. bib object formatted as marc-in-json
    *   2. array of item objects, each formatted as marc-in-json
    */
-  getBibAndItemsByBibId (bibId, barcode) {
+  getBibAndItemsByBibId (bibId, barcode, includeFullBibTree) {
     return this.dataApiClient().then((client) => {
       // Record start time to report `elapsed` on completion
       let startTime = new Date()
 
-      let urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&barcode=${barcode}`]
+      let urls = []
+      console.log(includeFullBibTree)
+
+      if (includeFullBibTree) {
+        urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&bibId=${bibId}&limit=100000`]
+      } else {
+        urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&barcode=${barcode}`]
+      }
 
       return Promise.all(
         urls.map((url) => client.get(url, { cache: false }))
@@ -79,7 +87,7 @@ class DataApi {
 
         // Report elapsed time
         let elapsed = (new Date()) - startTime
-        logger.debug(`Got bib and ${items.length} item(s) for bibId ${bibId}`, { bib, items, elapsed })
+        logger.debug(`Got bib and ${items.length} item(s) for bibId ${bibId}`)
 
         return [bib, items]
       })

--- a/lib/data-api.js
+++ b/lib/data-api.js
@@ -69,12 +69,11 @@ class DataApi {
       let startTime = new Date()
 
       let urls = []
-      console.log(includeFullBibTree)
 
       if (includeFullBibTree) {
         urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&bibId=${bibId}&limit=100000`]
       } else {
-        urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&barcode=${barcode}`]
+        urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&bibId=${bibId}`]
       }
 
       return Promise.all(

--- a/lib/data-api.js
+++ b/lib/data-api.js
@@ -73,7 +73,11 @@ class DataApi {
       if (includeFullBibTree) {
         urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&bibId=${bibId}&limit=100000`]
       } else {
-        urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&bibId=${bibId}`]
+        if (barcode) {
+          urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&barcode=${barcode}`]
+        } else {
+          urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&bibId=${bibId}`]
+        }
       }
 
       return Promise.all(

--- a/lib/data-api.js
+++ b/lib/data-api.js
@@ -56,17 +56,18 @@ class DataApi {
    *  Get bib and items for bibId
    *
    *  @param {string} bibId The bibId to look up.
+   *  @param {string} barcode The barcode of the item to attach.
    *
    *  @returns {array} with exactly two elements:
    *   1. bib object formatted as marc-in-json
    *   2. array of item objects, each formatted as marc-in-json
    */
-  getBibAndItemsByBibId (bibId) {
+  getBibAndItemsByBibId (bibId, barcode) {
     return this.dataApiClient().then((client) => {
       // Record start time to report `elapsed` on completion
       let startTime = new Date()
 
-      let urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&bibId=${bibId}&limit=10000`]
+      let urls = [`bibs/sierra-nypl/${bibId}`, `items?nyplSource=sierra-nypl&barcode=${barcode}`]
 
       return Promise.all(
         urls.map((url) => client.get(url, { cache: false }))

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@nypl/sierra-wrapper": "^0.2.0",
     "aws-sdk": "^2.118.0",
     "aws-serverless-express": "^3.0.2",
-    "convert-2-scsb-module": "https://github.com/NYPL-discovery/convert-2-scsb-module.git#1.0.5",
+    "convert-2-scsb-module": "https://github.com/NYPL-discovery/convert-2-scsb-module.git#1.0.6",
     "cors": "^2.8.4",
     "express": "^4.15.4",
     "highland": "^2.10.1",

--- a/swagger.v0.1.json
+++ b/swagger.v0.1.json
@@ -23,7 +23,7 @@
           "recap"
         ],
         "summary": "Get SCSB XML for a Sierra Bib",
-        "description": "Translate a Sierra Bib and associated items MARC records into ReCAP SCSB XML (see: https://htcrecap.atlassian.net/wiki/spaces/RTG/pages/27691070/XML+Schema)",
+        "description": "Translate a Sierra Bib and associated Items MARC records into ReCAP SCSB XML (see: https://htcrecap.atlassian.net/wiki/spaces/RTG/pages/27691070/XML+Schema)",
         "produces":[
           "text\/xml",
           "application\/json"

--- a/swagger.v0.1.json
+++ b/swagger.v0.1.json
@@ -61,7 +61,7 @@
         ],
         "responses": {
           "200": {
-            "description": "SCSB XML"
+            "description": "Response in SCSB XML format"
           },
           "500": {
             "description": "Error message in JSON format"

--- a/swagger.v0.1.json
+++ b/swagger.v0.1.json
@@ -23,7 +23,7 @@
           "recap"
         ],
         "summary": "Get SCSB XML for a Sierra Bib",
-        "description": "Translate a Sierra Bib MARC record and the associated items into ReCAP SCSB XML (see: https://htcrecap.atlassian.net/wiki/spaces/RTG/pages/27691070/XML+Schema)",
+        "description": "Translate a Sierra Bib and associated items MARC records into ReCAP SCSB XML (see: https://htcrecap.atlassian.net/wiki/spaces/RTG/pages/27691070/XML+Schema)",
         "produces":[
           "text\/xml",
           "application\/json"

--- a/swagger.v0.1.json
+++ b/swagger.v0.1.json
@@ -1,0 +1,73 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.1",
+    "title": "ReCAP Bib API",
+    "description": "Translate Sierra MARC bib/item data to ReCAP SCSB XML"
+  },
+  "host": "localhost:3000",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "tags": [
+    {
+      "name": "recap",
+      "description": "ReCAP API"
+    }
+  ],
+  "paths": {
+    "/v0.1/recap/nypl-bibs": {
+      "get": {
+        "tags": [
+          "recap"
+        ],
+        "summary": "Get SCSB XML for a Sierra Bib",
+        "description": "Translate a Sierra Bib MARC record and the associated items into ReCAP SCSB XML (see: https://htcrecap.atlassian.net/wiki/spaces/RTG/pages/27691070/XML+Schema)",
+        "produces":[
+          "text\/xml",
+          "application\/json"
+        ],
+        "parameters": [
+          {
+            "name": "customerCode",
+            "in": "query",
+            "description": "ReCAP customer code to use for associated Item(s)",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "barcode",
+            "in": "query",
+            "description": "Lookup the Bib by an associated Item barcode",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "bibId",
+            "in": "query",
+            "description": "Lookup the Bib by the Bib ID",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "includeFullBibTree",
+            "in": "query",
+            "description": "Return the full Bib tree (i.e. all Items) for the Bib",
+            "required": false,
+            "type": "boolean",
+            "default": "false"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SCSB XML"
+          },
+          "500": {
+            "description": "Error message in JSON format"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hello!

So, I made a few changes to this service that I think could be helpful:

- Added Swagger docs for the endpoint (now published to: http://platformdocs.nypl.org/#/recap/get_v0_1_recap_nypl_bibs)
- Added a `includeFullBibTree` query parameter on the request (default behavior is to only include the default limit response)
- Fixed functionality for and renamed the `bnumber` query parameter to `bibId`
- Bumped the `convert-2-scsb-module` version

I think that's it! 